### PR TITLE
contributors-trac-to-github.py, contributors-from-sage-changelogs: New

### DIFF
--- a/contributors-from-sage-changelogs.py
+++ b/contributors-from-sage-changelogs.py
@@ -1,0 +1,35 @@
+# Adapted from scripts/geocode.py
+
+import certifi
+import urllib3
+import pprint
+
+from xml.dom.minidom import parseString
+
+http = urllib3.PoolManager(
+    cert_reqs='CERT_REQUIRED',
+    ca_certs=certifi.where()
+)
+
+ack = parseString(http.request('GET', 'https://raw.githubusercontent.com/sagemath/website/master/conf/contributors.xml').data.decode('utf-8'))
+
+names = set()
+usernames = set()
+
+for c in ack.getElementsByTagName("contributors")[0].childNodes:
+    if c.nodeType != ack.ELEMENT_NODE:
+        continue
+    if c.tagName != "contributor":
+        continue
+    name = c.getAttribute("name")
+    if name.strip():
+        names.add(name.strip())
+    altnames = c.getAttribute("altnames")
+    names.update(n.strip() for n in altnames.split(',') if n.strip())
+    trac = c.getAttribute("trac")
+    usernames.update(t.strip() for t in trac.split(',') if t.strip())
+
+changelog_contributors = http.request('GET', 'https://raw.githubusercontent.com/sagemath/sage-changelogs/master/merger/contributors/9.7').data.decode('utf-8')
+for n in changelog_contributors.split('\n'):
+    if n not in names and n not in usernames:
+        print(n)

--- a/contributors-from-sage-changelogs.py
+++ b/contributors-from-sage-changelogs.py
@@ -30,6 +30,16 @@ for c in ack.getElementsByTagName("contributors")[0].childNodes:
     usernames.update(t.strip() for t in trac.split(',') if t.strip())
 
 changelog_contributors = http.request('GET', 'https://raw.githubusercontent.com/sagemath/sage-changelogs/master/merger/contributors/9.7').data.decode('utf-8')
-for n in changelog_contributors.split('\n'):
-    if n not in names and n not in usernames:
-        print(n)
+
+def last_name(n):
+    parts = n.split()
+    if parts:
+        return parts[-1]
+    return ""
+
+missing_names = [n
+                 for n in changelog_contributors.split('\n')
+                 if n and n not in names and n not in usernames]
+missing_names.sort(key=last_name)
+for n in missing_names:
+    print(f'<contributor\n name="{n}"/>')

--- a/contributors-trac-to-github.py
+++ b/contributors-trac-to-github.py
@@ -1,0 +1,38 @@
+# Adapted from scripts/geocode.py
+
+import certifi
+import urllib3
+import pprint
+
+from xml.dom.minidom import parseString
+
+http = urllib3.PoolManager(
+    cert_reqs='CERT_REQUIRED',
+    ca_certs=certifi.where()
+)
+
+ack = parseString(http.request('GET', 'https://raw.githubusercontent.com/sagemath/website/master/conf/contributors.xml').data.decode('utf-8'))
+
+usernames = {}
+
+for c in ack.getElementsByTagName("contributors")[0].childNodes:
+    if c.nodeType != ack.ELEMENT_NODE:
+        continue
+    if c.tagName != "contributor":
+        continue
+    trac = c.getAttribute("trac")
+    github = c.getAttribute("github")
+    if trac:
+        for t in trac.split(','):
+            t = t.strip()
+            if t:
+                if github:
+                    usernames[t] = github
+                elif t not in usernames:
+                    usernames[t] = None
+
+pprint.pp(usernames)
+
+
+print('# Trac accounts without github account: ' + ','.join(
+    t for t, g in usernames.items() if not g))


### PR DESCRIPTION
Updated version of the script, now handles comma-separated trac account lists in contributors.xml and outputs a list of Trac accounts without github account - I used this for https://trac.sagemath.org/ticket/34664

contributors-from-sage-changelogs.py: Finds names from https://github.com/sagemath/sage-changelogs/blob/master/merger/contributors/9.7 that are not included in contributors.xml yet -  @kwankyu