### PR TITLE
Prepare for writing migration archives

### DIFF
--- a/migrate.cfg.sagetracmigrationarchive
+++ b/migrate.cfg.sagetracmigrationarchive
@@ -39,6 +39,8 @@ project_name: username/projectname
 # GitHub password (if no token specified)
 #password: secret
 
+# Where to write a migration archive
+migration_archive: archive
 
 [issues]
 

--- a/migrate.cfg.sagetracmigrationarchive
+++ b/migrate.cfg.sagetracmigrationarchive
@@ -1,0 +1,76 @@
+# Sample configuration file, update to meet your needs
+
+[source]
+
+# URL of the XML-RPC trac endpoint
+# unauthenticated works for globally readable trac instances
+url: https://trac.sagemath.org/xmlrpc
+
+# authentication broken with python3.8 or later, due to
+# https://github.com/python/cpython/issues/82219
+# url: http://username:password@example.com/trac/login/xmlrpc
+
+# optional path to trac instance used to convert some attachments
+# path: /path/to/trac/instance
+
+# mapping file from git hashes to subversion revisions and branch names ("hash revision @branch" in each line)
+#svngitmap: /path/to/git_svn.map
+
+[target]
+
+# Trac to GitLab user mappings
+usernames = {
+    'trac1': 'git1',
+    'trac2': 'git2'
+    }
+
+# URL of the GitHub web API (default: https://api.github.com)
+# url: https://api.github.com
+
+# project's path
+project_name: username/projectname
+
+# GitHub access token
+#token : 2190valkrl123c
+
+# GitHub username (if no token specified)
+#username: johndoe
+
+# GitHub password (if no token specified)
+#password: secret
+
+
+[issues]
+
+# Should we migrate the issues (default = yes)
+migrate: yes
+
+# If defined, import only these issues
+# only_issues: [ 30000, 30001 ]
+
+# If defined, do not import these issues
+# blacklist_issues: [ 268, 843 ]
+
+# If defined, then this is added to the ticket query string to trac
+filter_issues: max=5&order=id&desc=False
+#filter_issues: max=2796&order=id&page=2
+
+# Add a label to all migrated issues
+# add_label: Websites
+
+# Migrate keywords to labels, or add to issue description
+# keywords_to_labels: no
+
+# Migrate milestones
+migrate_milestones: no
+
+[attachments]
+
+# Export attachement as files to the local filesystem or try to upload them as Gist?
+# Gist only allows text files, so binary attachments will be lost
+# Gists are associated with the GitHub user, not the project
+export : no
+
+[wiki]
+
+migrate : no

--- a/migrate.cfg.sagetracmigrationarchive
+++ b/migrate.cfg.sagetracmigrationarchive
@@ -54,7 +54,7 @@ migrate: yes
 # blacklist_issues: [ 268, 843 ]
 
 # If defined, then this is added to the ticket query string to trac
-filter_issues: max=5&order=id&desc=False
+filter_issues: max=200&order=id&desc=False
 #filter_issues: max=2796&order=id&page=2
 
 # Add a label to all migrated issues
@@ -76,3 +76,5 @@ export : no
 [wiki]
 
 migrate : no
+
+export_dir: wiki

--- a/migrate.py
+++ b/migrate.py
@@ -856,8 +856,8 @@ def convert_issues(source, dest, only_issues = None, blacklist_issues = None):
                 # we will forget about these old versions and only keep the latest one
                 pass
             elif change_type == "status" :
-                # we map here the various statii we have in trac to just 2 statii in gitlab (open or close), so loose some information
-                if newvalue in ['new', 'assigned', 'analyzed', 'reopened', 'needs_review', 'needs_work', 'positive_review'] :
+                # we map here the various statuses we have in trac to just 2 statuses in gitlab (open or close), so lose some information
+                if newvalue in ['new', 'assigned', 'analyzed', 'reopened', 'needs_review', 'needs_work', 'needs_info', 'positive_review'] :
                     newstate = 'open'
                     # should not need an extra comment if closing ticket
                     gh_comment_issue(dest, issue, {'note' : 'Changing status from ' + oldvalue + ' to ' + newvalue + '.', 'created_at' : change_time, 'author' : author})
@@ -970,7 +970,7 @@ def convert_issues(source, dest, only_issues = None, blacklist_issues = None):
                     gh_update_issue_property(dest, issue, 'labels', labels)
                 else :
                     gh_comment_issue(dest, issue, { 'note' : 'Changing keywords from "' + oldvalue + '" to "' + newvalue + '".', 'created_at' : change_time, 'author' : author })
-            elif change_type in ["commit",  "upstream",  "stopgaps", "branch", "reviewer", "work_issues", "merged", "dependencies", "author"] :
+            elif change_type in ["commit",  "upstream",  "stopgaps", "branch", "reviewer", "work_issues", "merged", "dependencies", "author", "changetime"] :
                 print("TODO Change type: ", change_type)
             else :
                 raise BaseException("Unknown change type " + change_type)

--- a/migrate.py
+++ b/migrate.py
@@ -113,6 +113,9 @@ elif config.has_option('target', 'username'):
 else:
     github_username = None
 github_project = config.get('target', 'project_name')
+migration_archive = None
+if config.has_option('target', 'migration_archive'):
+    migration_archive = config.get('target', 'migration_archive')
 
 users_map = ast.literal_eval(config.get('target', 'usernames'))
 must_convert_issues = config.getboolean('issues', 'migrate')
@@ -1167,7 +1170,7 @@ if __name__ == "__main__":
                 gh_labels[l.name.lower()] = l
             #print 'Existing labels:', gh_labels.keys()
         else:
-            requester = MigrationArchiveWritingRequester()
+            requester = MigrationArchiveWritingRequester(migration_archive)
             dest = Repository(requester, None, dict(name="sagetest",
                                                     url="https://github.com/sagemath/sagetest"), None)
             print(dest.url)

--- a/migrate.py
+++ b/migrate.py
@@ -825,7 +825,7 @@ def convert_issues(source, dest, only_issues = None, blacklist_issues = None):
             time, author, change_type, oldvalue, newvalue, permanent = change
             change_time = str(convert_xmlrpc_datetime(time))
             print(change)
-            print(("  %s by %s (%s -> %s)" % (change_type, author, oldvalue[:40].replace("\n", " "), newvalue[:40].replace("\n", " "))).encode("ascii", "replace"))
+            print(("  %s by %s (%s -> %s)" % (change_type, author, str(oldvalue)[:40].replace("\n", " "), str(newvalue)[:40].replace("\n", " "))).encode("ascii", "replace"))
             #assert attachment is None or change_type == "comment", "an attachment must be followed by a comment"
             if author in ['anonymous', 'Draftmen888'] :
                 print ("  SKIPPING CHANGE BY", author)

--- a/migration_archive_writer.py
+++ b/migration_archive_writer.py
@@ -1,0 +1,32 @@
+import json
+from urllib.parse import urlparse
+from copy import copy
+
+# class MigrationArchiveWriter:
+
+#     # https://github.com/PyGithub/PyGithub/blob/master/github/Repository.py
+#     def create_issue(
+#         self,
+#         title,
+#         body=None,
+#         assignee=None,
+#         milestone=None,
+#         labels=None,
+#         assignees=None,
+#     ):
+
+
+class MigrationArchiveWritingRequester:
+
+    def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None):
+
+        parse_result = urlparse(url)
+        endpoint = parse_result.path.split('/')[3:]
+        #if endpoint[0] == 'issues'
+        responseHeaders = None
+        output = copy(input)
+        # TODO: On POST, append number
+        if isinstance(output, dict):
+            output['url'] = url
+        print(json.dumps(output, sort_keys=True, indent=4))
+        return responseHeaders, output

--- a/migration_archive_writer.py
+++ b/migration_archive_writer.py
@@ -1,5 +1,7 @@
 import json
-from urllib.parse import urlparse
+import pathlib
+from urllib.parse import urlparse, urlunparse, urljoin, quote
+from collections import defaultdict
 from copy import copy
 
 # class MigrationArchiveWriter:
@@ -15,18 +17,63 @@ from copy import copy
 #         assignees=None,
 #     ):
 
+def pluralize(t):
+    if t.endswith('y'):
+        return t[:-1] + 'ies'
+    return t + 's'
 
 class MigrationArchiveWritingRequester:
 
-    def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None):
+    def __init__(self, migration_archive=None):
+        if migration_archive is None:
+            self._migration_archive = None
+        else:
+            self._migration_archive = pathlib.Path(migration_archive)
+            self._migration_archive.mkdir(parents=True, exist_ok=True)
+        self._num_issues = 0
+        self._num_issue_comments = 0
+        self._num_json_by_type = defaultdict(lambda: 0)
 
+    def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None):
+        print(f'# {verb=} {url=} {parameters=} {headers=} {input=}')
         parse_result = urlparse(url)
+        print(parse_result.path)
         endpoint = parse_result.path.split('/')[3:]
-        #if endpoint[0] == 'issues'
+        base_url = urlunparse([parse_result.scheme,
+                               parse_result.netloc,
+                               '/'.join(parse_result.path.split('/')[:3]) + '/',
+                               None, None, None])
+        print(f'{base_url=} {endpoint=}')
         responseHeaders = None
         output = copy(input)
-        # TODO: On POST, append number
+        match verb, endpoint:
+            case 'POST', ['labels']:
+                output['type'] = 'label'
+                url = urljoin(base_url, f'labels/' + quote(input['name']))
+            case 'POST', ['issues']:
+                # Create a new issue
+                output['type'] = 'issue'
+                self._num_issues += 1
+                id = self._num_issues
+                url = urljoin(base_url, f'issues/{id}')
+            case 'POST', ['issues', issue, 'comments']:
+                # Create an issue comment
+                output['type'] = 'issue_comment'
+                output['issue'] = urljoin(base_url, f'issues/{issue}')
+                self._num_issue_comments += 1
+                id = self._num_issue_comments
+                url = urljoin(base_url, f'issues/{issue}#issuecomment-{id}')
         if isinstance(output, dict):
             output['url'] = url
-        print(json.dumps(output, sort_keys=True, indent=4))
+            dump = json.dumps(output, sort_keys=True, indent=4)
+            if self._migration_archive and 'type' in output:
+                t = output['type']
+                self._num_json_by_type[t] += 1
+                id = self._num_json_by_type[t]
+                json_file = self._migration_archive / f'{pluralize(t)}_{id:06}.json'
+                with open(json_file, 'w') as f:
+                    f.write(dump)
+                print(f'# Wrote {json_file}')
+            else:
+                print(dump)
         return responseHeaders, output


### PR DESCRIPTION
As described in #11, we add a mode for the migration script in which migration archives are written out.

In addition, we write converted tickets (including comments) out as .md files (for inspection of the markup conversion). Results pushed to the temporary wiki, for example https://github.com/sagemath/trac_to_gh/wiki/Issue-39   @kwankyu @soehms
