### PR TITLE
Add table alignment instructions

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -226,9 +226,13 @@ def trac2markdown(text, base_path, multilines = True, trac_ticket_url=None) :
                 line = re.sub(r'\#([1-9]\d{0,4})', r'[#\1](%s/\1)' % trac_ticket_url, line)
             if line.startswith('||'):
                 if not is_table:
-                    sep = re.sub(r'[^|]', r'-', line)
+                    sep = re.sub(r'\|\|=', r'||:', line) # take care of left align
+                    sep = re.sub(r'=\|\|', r':||', sep)  # take care of right align
+                    sep = re.sub(r'[^|,^:]', r'-', sep)
                     line = line + '\n' + sep
                     is_table = True
+                line = re.sub(r'\|\|=', r'||', line) # ignore cellwise align instructions
+                line = re.sub(r'=\|\|', r'||', line) # ignore cellwise align instructions
                 line = re.sub(r'\|\|', r'|', line)
             else:
                 is_table = False

--- a/migrate.py
+++ b/migrate.py
@@ -231,6 +231,9 @@ def trac2markdown(text, base_path, multilines = True, trac_ticket_url=None) :
                     sep = re.sub(r'[^|,^:]', r'-', sep)
                     line = line + '\n' + sep
                     is_table = True
+                # The wiki markup allows the alignment directives to be specified on a cell-by-cell
+                # basis. This is used in many examples. AFAIK this can't be properly translated into
+                # the GitHub markdown as it only allows to align statements column by column.
                 line = re.sub(r'\|\|=', r'||', line) # ignore cellwise align instructions
                 line = re.sub(r'=\|\|', r'||', line) # ignore cellwise align instructions
                 line = re.sub(r'\|\|', r'|', line)


### PR DESCRIPTION
As mentioned in [this post on sage-devel](https://groups.google.com/g/sage-devel/c/xtwaueSUJI0/m/cEIK9_uSBgAJ), I add the lines of code to translate the alignment instructions. Note that the wiki markup allows these directives to be specified on a cell-by-cell basis. This is used in many examples. AFAIK this can't be properly translated into the GitHub markdown as it only allows to align statements column by column. So I translate the alignments set in the header and ignore all others.
