### PR TITLE
Fix for item A6 and A8 of issue #18

### DIFF
--- a/migrate.cfg.sagetracwikionly
+++ b/migrate.cfg.sagetracwikionly
@@ -7,8 +7,8 @@
 # unauthenticated works for globally readable trac instances
 url: https://trac.sagemath.org/xmlrpc
 
-# Optional ticket_url if links to the Trac tickets should be set in md-documents
-ticket_url: https://trac.sagemath.org/ticket
+# Should references to tickets still point to Trac?
+keep_trac_ticket_references: yes
 
 # authentication broken with python3.8 or later, due to
 # https://github.com/python/cpython/issues/82219

--- a/migrate.py
+++ b/migrate.py
@@ -194,7 +194,7 @@ def trac2markdown(text, base_path, conv_help, multilines = True) :
     if multilines:
         text = re.sub(r'^\S[^\n]+([^=-_|])\n([^\s`*0-9#=->-_|])', r'\1 \2', text)
 
-    def convert_headding(level, text):
+    def convert_heading(level, text):
         """
         Return the given text with converted headdings
         """
@@ -202,13 +202,18 @@ def trac2markdown(text, base_path, conv_help, multilines = True) :
             """
             Return the replacement for the headding
             """
-            headding = match.groups()[0]
-            return '%s %s\n' % (('#'*level), headding)
+            heading = match.groups()[0]
+            # There might be a second item if an anchor is set.
+            # We ignore this anchor since it is automatically
+            # set it GitHub Markdown.
+            return '%s %s' % (('#'*level), heading)
 
-        return re.sub(r'(?m)^%s\s+(.*?)\s+%s\s*([^\n]\s*[\#][\w-]*)?$' % ('='*level, '='*level), replace, text)
+        text = re.sub(r'(?m)^%s\s+([^=]+)[^\n=]*([\#][\w-]*)?$' % ('='*level), replace, text)
+        text = re.sub(r'(?m)^%s\s+(.*?)\s+%s[^\n]*([\#][\w-]*)?$' % ('='*level, '='*level), replace, text)
+        return text
 
     for level in [6, 5, 4, 3, 2, 1]:
-        text = convert_headding(level, text)
+        text = convert_heading(level, text)
 
     text = re.sub(r'^             * ', r'****', text)
     text = re.sub(r'^         * ', r'***', text)

--- a/migrate.py
+++ b/migrate.py
@@ -193,12 +193,22 @@ def trac2markdown(text, base_path, multilines = True, trac_ticket_url=None) :
     if multilines:
         text = re.sub(r'^\S[^\n]+([^=-_|])\n([^\s`*0-9#=->-_|])', r'\1 \2', text)
 
-    text = re.sub(r'(?m)^======\s+(.*?)\s+======$', r'\n###### \1', text)
-    text = re.sub(r'(?m)^=====\s+(.*?)\s+=====$', r'\n##### \1', text)
-    text = re.sub(r'(?m)^====\s+(.*?)\s+====$', r'\n#### \1', text)
-    text = re.sub(r'(?m)^===\s+(.*?)\s+===$', r'\n### \1', text)
-    text = re.sub(r'(?m)^==\s+(.*?)\s+==$', r'\n## \1', text)
-    text = re.sub(r'(?m)^=\s+(.*?)\s+=$', r'\n# \1', text)
+    def convert_headding(level, text):
+        """
+        Return the given text with converted headdings
+        """
+        def replace(match):
+            """
+            Return the replacement for the headding
+            """
+            headding = match.groups()[0]
+            return '%s %s\n' % (('#'*level), headding)
+
+        return re.sub(r'(?m)^%s\s+(.*?)\s+%s\s*([^\n]\s*[\#][\w-]*)?$' % ('='*level, '='*level), replace, text)
+
+    for level in [6, 5, 4, 3, 2, 1]:
+        text = convert_headding(level, text)
+
     text = re.sub(r'^             * ', r'****', text)
     text = re.sub(r'^         * ', r'***', text)
     text = re.sub(r'^     * ', r'**', text)


### PR DESCRIPTION
As mentioned in the [second comment](https://github.com/sagemath/trac-to-github/issues/18#issuecomment-1321561738) of #18, these two items are due to obscure code in `migration.py`. I'm not removing it entirely, as later it might turn out to be useful in certain situations. So I make it dependent on options that can be set in the configuration file.

This PR depends on PR #19 and PR #21 not because of a functional dependency. It's just to make it easier to interpret the result, which can be viewed [here](https://github.com/soehms/trac_to_gh/wiki)