### PR TITLE
Refactor project specific code

### DIFF
--- a/migrate.cfg.sagetracmigrationarchive
+++ b/migrate.cfg.sagetracmigrationarchive
@@ -11,7 +11,13 @@ url: https://trac.sagemath.org/xmlrpc
 # url: http://username:password@example.com/trac/login/xmlrpc
 
 # optional path to trac instance used to convert some attachments
-# path: /path/to/trac/instance
+path: sage_trac
+
+# optional prefix used for Trac milestones
+milestone_prefix: sage-
+
+# optional url for cgit repository access
+cgit_url: https://git.sagemath.org/sage.git/
 
 # if no, a trac ticket reference is converted to the corresponding issue reference
 keep_trac_ticket_references: yes
@@ -40,6 +46,43 @@ keywords_to_labels: {'beginner': 'good first issue'}
 
 # Migrate milestones
 migrate_milestones: yes
+
+# Map for certain Trac milestones to GitHub labels
+milestones_to_labels = {
+ 'sage-duplicate/invalid/wontfix': 'duplicate/invalid/wontfix',
+ 'sage-duplicate/invalid': 'duplicate/invalid/wontfix',
+ 'sage-duplicate': 'duplicate/invalid/wontfix',
+ 'sage-wait': 'pending',
+ 'sage-pending': 'pending',
+ 'sage-feature': 'feature',
+ 'sage-wishlist': 'wishlist',
+ 'sage-combinat': 'component: combinatorics',
+ 'sage-symbolics': 'component: symbolics',
+ 'sage-i18n': 'component: translations'}
+
+# Map for canceld Trac milestones to GitHub milestones
+canceled_milestones = {
+ 'sage-2.8.4.3': 'sage-2.8.5',
+ 'sage-3.2.4': 'sage-3.3',
+ 'sage-4.0.3': 'sage-4.1',
+ 'sage-4.1.3': 'sage-4.2',
+ 'sage-4.4.5': 'sage-4.5',
+ 'sage-4.7.3': 'sage-4.8',
+ 'sage-6.11': 'sage-7.0',
+ 'sage-7.7': 'sage-8.0'}
+
+# Map for certain Trac components to GitHub labels
+components_to_labels = {
+ 'solaris': 'porting: solaris',
+ 'cygwin': 'porting: cygwin',
+ 'freebsd': 'porting: bsd',
+ 'aix or hp-ux ports': 'porting: aix or hp-ux',
+ 'experimental package': 'packages: experimental',
+ 'optional packages': 'packages: optional',
+ 'plotting': 'graphics',
+ 'doctest': 'doctest coverage',
+ 'sage-check': 'spkg-check'}
+
 
 [attachments]
 
@@ -83,6 +126,9 @@ project_name: sagemath/sage
 
 # GitHub password (if no token specified)
 #password: secret
+
+# optional prefix used for GitHub milestones
+milestone_prefix: sage-
 
 # Where to write a migration archive
 migration_archive: archive
@@ -1055,3 +1101,6 @@ usernames = {
  'arattan': None,
  'joskarsson': None,
  'shahuwang': None}
+
+
+unknown_users_prefix: sagetrac-

--- a/migrate.cfg.sagetracwikionly
+++ b/migrate.cfg.sagetracwikionly
@@ -14,6 +14,9 @@ url: https://trac.sagemath.org/xmlrpc
 # optional path to trac instance used to convert some attachments
 # path: /path/to/trac/instance
 
+# optional url for cgit repository access
+cgit_url: https://git.sagemath.org/sage.git/
+
 # if no, a trac ticket reference is converted to the corresponding issue reference
 keep_trac_ticket_references: yes
 


### PR DESCRIPTION
@kwankyu, @mkoeppe I'm sorry I haven't found time to help here for a few weeks. While trying to update myself (at least a bit), I noticed that in the heat of development, a lot of Sage-specific code ended up in the `migration.py` file.

```
(sage-sh) sebastian@ThinkPadKlein:trac-to-github$ grep -ci ^[^\#]*sage migrate.py
102
```

So I'm proposing this PR to relegate this to the config files. The patch produces exactly the same output as the previous commit, but reduces the Sage-specific coding in the Python file:

```
(sage-sh) sebastian@ThinkPadKlein:trac-to-github$ grep -i ^[^\#]*sage migrate.py
Modified and extended for the migration of SageMath from Trac to GitHub.
            Decode title prefixes such as [with patch, positive review] used in early Sage tickets.
    FORMAT = "%(message)s"
```

Furthermore, I do some cleaning in terms of avoidable use of literals.

BTW: I noticed this `unknown milestone "sage-9.1.1"` (with and without the patch):

```
           INFO     Migrating ticket #25316 ( 58 changes): "Replace python 5755 patch by monkey patch"                                                                                                                                                                                                                                                      migrate.py:1853
           WARNING  Ignoring unknown milestone "sage-9.1.1"                                                                                                                                                                                                                                                                                                 migrate.py:2194
           WARNING  Ignoring unknown milestone "sage-9.1.1"                                                                                                                                                                                                                                                                                                 migrate.py:2187
           INFO     Migrating ticket #25317 ( 20 changes): "Special-case pol*term, term*pol for generic polyno"                                                                                                                                                                                                                                             migrate.py:1853
....
   Unmapped milestones
┏━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃  Milestone ┃ Frequency ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ sage-9.1.1 │ 18        │
└────────────┴───────────┘
```


It is not present in the `unmapped_milestones.txt`. Where does it come from? I didn't find it in any Trac ticket.

The following questions go back in time, but I couldn't find answers for them:

1. I'm wondering why renaming `WikiStart` to `Home` was dropped as it breaks the start page for the GitHub wiki (assuming it will be chosen as the final destination). What is the intention? Will it be replaced by a softlink?

2. I still don't understand the need to delete the wiki subtree. I agree with the argument given in the [comment dated 12/22/16](https://github.com/sagemath/trac-to-github/pull/26#issuecomment-1354734423) of PR #26 that there could be ambiguities (theoretically). But I don't see any examples of this. Anyway, if this is necessary, why are we using whitespaces as delimiters in filenames?
