### PR TITLE
Fix for issue #68

### DIFF
--- a/docs/Migration-Trac-to-Github.md
+++ b/docs/Migration-Trac-to-Github.md
@@ -85,9 +85,15 @@ See also: https://trac.sagemath.org/ticket/30363
   - [Create the PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
   - If it is not ready for review, [mark the PR as a "Draft"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request)
 
-- For contributing a change that addresses an existing open Issue, **instead of pushing a git branch to a Trac ticket**:
+- For contributing a change that addresses an existing open Issue that has been created on GitHub, **instead of pushing a git branch to a Trac ticket**:
   - same as above
   - [use `Fixes #ISSUENUMBER` to link to an existing issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue); this will auto-close the linked Issue when the PR is merged.
+
+- For contributing a change that addresses an existing open Issue that has been migrated from Trac, **instead of pushing a git branch to a Trac ticket**:
+  - Pull the branch from your read-only `trac` remote (see section *One time action: Instead of adding a git remote named trac*) as you use to do before.
+  - Edit and commit your changes
+  - Push the branch to the remote named `origin`, i.e., to your fork
+  - Follow the instructions above from there
 
 - For finding PRs that are waiting for review, **instead of using Trac ticket reports**:
   - [filter PRs by review status](https://docs.github.com/en/issues/tracking-your-work-with-issues/filtering-and-searching-issues-and-pull-requests#filtering-pull-requests-by-review-status)


### PR DESCRIPTION
Add instructions to `docs/Migration-Trac-to-Github.md` on how to work on a migrated open Trac ticket.
This fixes #68.
