### PR TITLE
Fix raw attachment url

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -338,7 +338,8 @@ RE_HTTPS4 = re.compile(r'\[(https?://[^\s\[\]\|]+)\]')
 RE_TICKET_COMMENT1 = re.compile(r'\[\[ticket:([1-9]\d*)#comment:([1-9]\d*)\s*\|\s*(.+?)\]\]')
 RE_TICKET_COMMENT2 = re.compile(r'\[\[ticket:([1-9]\d*)#comment:([1-9]\d*)\]\]')
 RE_TICKET_COMMENT3 = re.compile(r'\[ticket:([1-9]\d*)#comment:([1-9]\d*)\s+(.*?)\]')
-RE_TICKET_COMMENT4 = re.compile(r'ticket:([1-9]\d*)#comment:([1-9]\d*)')
+RE_TICKET_COMMENT4 = re.compile(r'\[ticket:([1-9]\d*)#comment:([0])\s+(.*?)\]')
+RE_TICKET_COMMENT5 = re.compile(r'ticket:([1-9]\d*)#comment:([1-9]\d*)')
 RE_COMMENT1 = re.compile(r'\[\[comment:([1-9]\d*)\s*\|\s*(.+?)\]\]')
 RE_COMMENT2 = re.compile(r'\[comment:([1-9]\d*)\s+(.*?)\]')
 RE_COMMENT3 = re.compile(r'(?<=\s)comment:([1-9]\d*)')  # need to exclude the string as part of http url
@@ -639,6 +640,7 @@ cgit_conv_help = CgitConversionHelper(cgit_url)
 
 RE_WRONG_FORMAT1 = re.compile(r'comment:(\d+):ticket:(\d+)')
 RE_REPLYING_TO = re.compile(r'Replying to \[comment:(\d+)\s([\-\w0-9@._]+)\]')
+RE_REPLYING_TO_TICKET = re.compile(r'Replying to \[ticket:(\d+)\s([\-\w0-9@._]+)\]')
 
 def inline_code_snippet(match):
     code = match.group(1)
@@ -658,6 +660,17 @@ def convert_replying_to(match):
         name = username
 
     return 'Replying to [comment:{} {}]'.format(comment_id, name)
+
+def convert_replying_to_ticket(match):
+    ticket_id = match.group(1)
+    username = match.group(2)
+    name = convert_trac_username(username)
+    if name:  # github username
+        name = '@' + name
+    else:
+        name = username
+
+    return 'Replying to [ticket:{}#comment:0 {}]'.format(ticket_id, name)
 
 def commits_list(match):
     t = match.group(1) + '\n'
@@ -701,6 +714,7 @@ def trac2markdown(text, base_path, conv_help, multilines=default_multilines):
     # some normalization
     text = RE_WRONG_FORMAT1.sub(r'ticket:\2#comment:\1', text)
     text = RE_REPLYING_TO.sub(convert_replying_to, text)
+    text = RE_REPLYING_TO_TICKET.sub(convert_replying_to_ticket, text)
 
     text = re.sub('\r\n', '\n', text)
     text = re.sub(r'\swiki:([a-zA-Z]+)', r' [wiki:\1]', text)
@@ -951,6 +965,7 @@ def trac2markdown(text, base_path, conv_help, multilines=default_multilines):
             line = RE_TICKET_COMMENT2.sub(conv_help.ticket_comment_link, line)
             line = RE_TICKET_COMMENT3.sub(conv_help.ticket_comment_link, line)
             line = RE_TICKET_COMMENT4.sub(conv_help.ticket_comment_link, line)
+            line = RE_TICKET_COMMENT5.sub(conv_help.ticket_comment_link, line)
 
             line = RE_COMMENT1.sub(conv_help.comment_link, line)
             line = RE_COMMENT2.sub(conv_help.comment_link, line)
@@ -2100,7 +2115,7 @@ def convert_issues(source, dest, only_issues = None, blacklist_issues = None):
             return 'none'
 
         def issue_description(src_ticket_data):
-            description_pre = ""
+            description_pre = '<div id="comment:0"></div>\n\n'
             description_post = ""
 
             description_post_items = []


### PR DESCRIPTION
I found more conversion problems:

- wrong url to raw-attachment, seen in https://34.105.185.241/sagemath/sage-all-2023-01-14-014/issues/34850#issuecomment-5614045 (compare with https://github.com/kwankyu/trac-to-github/blob/check/wiki/Issues-34xxx/34850.md#comment:70)

- missing line after interrupted codeblock, seen in https://34.105.185.241/sagemath/sage-all-2023-01-14-014/issues/1242#issuecomment-5058039 (compare with https://trac.sagemath.org/ticket/1242#comment:2 `}}}` at the end). The missing lines I found are all trivial (or better like in the previous case), but can be significant in principle.

- discontinued quote block, seen in https://34.105.185.241/sagemath/sage-all-2023-01-14-014/issues/34850#issuecomment-5614011 (of course, there are lots of this) (compare with https://github.com/kwankyu/trac-to-github/blob/check/wiki/Issues-34xxx/34850.md#comment:36)

- wrong link for "replying to ticket", seen in https://34.105.185.241/sagemath/sage-all-2023-01-14-014/issues/1242#issuecomment-5058039

Note that the description comment (the first comment of an issue) is now with id "comment:0". This is not visible.

There should be no regressions, but as always I cannot be sure.
