### PR TITLE
Fix ticket-comment links in another form

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -339,7 +339,8 @@ RE_TICKET_COMMENT1 = re.compile(r'\[\[ticket:([1-9]\d*)#comment:([1-9]\d*)\s*\|\
 RE_TICKET_COMMENT2 = re.compile(r'\[\[ticket:([1-9]\d*)#comment:([1-9]\d*)\]\]')
 RE_TICKET_COMMENT3 = re.compile(r'\[ticket:([1-9]\d*)#comment:([1-9]\d*)\s+(.*?)\]')
 RE_TICKET_COMMENT4 = re.compile(r'\[ticket:([1-9]\d*)#comment:([0])\s+(.*?)\]')
-RE_TICKET_COMMENT5 = re.compile(r'ticket:([1-9]\d*)#comment:([1-9]\d*)')
+RE_TICKET_COMMENT5 = re.compile(r'\[comment:ticket:([1-9]\d*):([1-9]\d*)\s+(.*?)\]')
+RE_TICKET_COMMENT6 = re.compile(r'ticket:([1-9]\d*)#comment:([1-9]\d*)')
 RE_COMMENT1 = re.compile(r'\[\[comment:([1-9]\d*)\s*\|\s*(.+?)\]\]')
 RE_COMMENT2 = re.compile(r'\[comment:([1-9]\d*)\s+(.*?)\]')
 RE_COMMENT3 = re.compile(r'(?<=\s)comment:([1-9]\d*)')  # need to exclude the string as part of http url
@@ -966,6 +967,7 @@ def trac2markdown(text, base_path, conv_help, multilines=default_multilines):
             line = RE_TICKET_COMMENT3.sub(conv_help.ticket_comment_link, line)
             line = RE_TICKET_COMMENT4.sub(conv_help.ticket_comment_link, line)
             line = RE_TICKET_COMMENT5.sub(conv_help.ticket_comment_link, line)
+            line = RE_TICKET_COMMENT6.sub(conv_help.ticket_comment_link, line)
 
             line = RE_COMMENT1.sub(conv_help.comment_link, line)
             line = RE_COMMENT2.sub(conv_help.comment_link, line)


### PR DESCRIPTION
There is another form of ticket-comment links, seen in 

https://34.105.185.241/sagemath/sage-all-2023-01-14-015/issues/9512#issuecomment-5696801

(compare with https://trac.sagemath.org/ticket/9512#comment:5 and https://github.com/kwankyu/trac-to-github/blob/check/wiki/Issues-09xxx/9512.md#comment:5). There are lots of these broken links.