### PR TITLE
Fix line breaks

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -400,6 +400,8 @@ class CodeTag:
         self._code = code
 
 at_sign = CodeTag('AT__SIGN__IN__CODE', '@')
+linebreak_sign1 =  CodeTag('LINEBREAK__SIGN1__IN__CODE', r'\\')
+linebreak_sign2 =  CodeTag('LINEBREAK__SIGN2__IN__CODE', r'[[br]]')
 
 class Brackets:
     """
@@ -646,7 +648,9 @@ RE_REPLYING_TO_TICKET = re.compile(r'Replying to \[ticket:(\d+)\s([\-\w0-9@._]+)
 
 def inline_code_snippet(match):
     code = match.group(1)
-    code = code.replace('@', at_sign.tag)
+    code = code.replace(r'@', at_sign.tag)
+    code = code.replace(r'\\', linebreak_sign1.tag)
+    code = code.replace(r'[[br]]', linebreak_sign2.tag)
     if '`' in code:
         return '<code>' + code.replace('`', r'\`') + '</code>'
     else:
@@ -933,9 +937,6 @@ def trac2markdown(text, base_path, conv_help, multilines=default_multilines):
             line = new_line
 
         if not (in_code or in_html):
-            line = RE_LINEBREAK1.sub('\n', line)
-            line = RE_LINEBREAK2.sub('\n', line)
-
             # heading
             line = re.sub(r'^(\s*)# ', r'\1\# ', line)  # first fix unintended heading
             line = RE_HEADING1.sub(heading_replace, line)
@@ -1122,6 +1123,10 @@ def trac2markdown(text, base_path, conv_help, multilines=default_multilines):
                 elif t == 'i':
                     line = line.replace('i', toRoman(c).lower(), 1)
 
+            if not in_table:
+                line = RE_LINEBREAK1.sub('\n', line)
+                line = RE_LINEBREAK2.sub('\n', line)
+
         # only for table with td blocks:
         if in_table:
             if line == '|\\' or line == '| \\':  # leads td block
@@ -1178,6 +1183,8 @@ def trac2markdown(text, base_path, conv_help, multilines=default_multilines):
     text = proc_code.replace(text)
     text = link_displ.replace(text)
     text = at_sign.replace(text)
+    text = linebreak_sign1.replace(text)
+    text = linebreak_sign2.replace(text)
 
     # Some rewritings
     text = RE_COLOR.sub(r'$\\textcolor{\1}{\\text{\2}}$', text)

--- a/migrate.py
+++ b/migrate.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 '''
-Copyright © 2022 Matthias Koeppe
-                 Kwankyu Lee
-                 Sebastian Oehms
-                 Dima Pasechnik
+Copyright © 2022-2023 Matthias Koeppe
+                      Kwankyu Lee
+                      Sebastian Oehms
+                      Dima Pasechnik
 
 Modified and extended for the migration of SageMath from Trac to GitHub.
 

--- a/migrate.py
+++ b/migrate.py
@@ -1224,7 +1224,7 @@ def trac2markdown(text, base_path, conv_help, multilines=default_multilines):
 
     # Some rewritings
     text = RE_COLOR.sub(r'$\\textcolor{\1}{\\text{\2}}$', text)
-    text = RE_TRAC_REPORT.sub(r'[Trac report of id \1 inherited from the migration](%s/\1)' % trac_url_report, text)
+    text = RE_TRAC_REPORT.sub(r'[Trac report of id \1](%s/\1)' % trac_url_report, text)
     text = RE_NEW_COMMITS.sub(commits_list, text)
     text = RE_LAST_NEW_COMMITS.sub(commits_list, text)
 
@@ -1406,7 +1406,7 @@ class WikiConversionHelper:
             args = None
             if len(macro_split) > 1:
                 args =  macro_split[1][:-1]  # remove ')'
-            display = 'This is the Trac macro *%s*' % macro
+            display = 'Trac macro *%s*' % macro
             link = '%s/WikiMacros#%s-macro' % (trac_url_wiki, macro)
             if args:
                 return self.protect_wiki_link('%s called with arguments (%s)' % (display, args), link)

--- a/migrate.py
+++ b/migrate.py
@@ -312,6 +312,8 @@ elif must_convert_wiki:
 
 RE_CAMELCASE1 = re.compile(r'(?<=\s)((?:[A-Z][a-z0-9]+){2,})(?=[\s\.\,\:\;\?\!])')
 RE_CAMELCASE2 = re.compile(r'(?<=\s)((?:[A-Z][a-z0-9]+){2,})$')
+RE_LINEBREAK1 = re.compile(r'\[\[br\]\]\s+')
+RE_LINEBREAK2 = re.compile(r'\\\\\s+')
 RE_HEADING1 = re.compile(r'^(=)\s(.+)\s=\s*([\#][^\s]*)?')
 RE_HEADING2 = re.compile(r'^(==)\s(.+)\s==\s*([\#][^\s]*)?')
 RE_HEADING3 = re.compile(r'^(===)\s(.+)\s===\s*([\#][^\s]*)?')
@@ -931,6 +933,9 @@ def trac2markdown(text, base_path, conv_help, multilines=default_multilines):
             line = new_line
 
         if not (in_code or in_html):
+            line = RE_LINEBREAK1.sub('\n', line)
+            line = RE_LINEBREAK2.sub('\n', line)
+
             # heading
             line = re.sub(r'^(\s*)# ', r'\1\# ', line)  # first fix unintended heading
             line = RE_HEADING1.sub(heading_replace, line)


### PR DESCRIPTION
Seen in https://34.105.185.241/sagemath/sage-all-2023-01-14-015/issues/8156#issuecomment-5677548 (compare with https://trac.sagemath.org/ticket/8156#comment:15).

I removed the phrase "that was inherited from the migration" from  "This is the Trac macro ** that was inherited from the migration", which seems unnecessary and just makes the sentence long.