### PR TITLE
Make trac macro sentence short

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -1517,8 +1517,8 @@ class IssuesConversionHelper(WikiConversionHelper):
             macro = macro_split[0]
             args = None
             if len(macro_split) > 1:
-                args =  macro_split[1]
-            display = 'This is the Trac macro *%s* that was inherited from the migration' % macro
+                args =  macro_split[1][:-1]  # remove ')'
+            display = 'Trac macro *%s*' % macro
             link = '%s/WikiMacros#%s-macro' % (trac_url_wiki, macro)
             if args:
                 return self.protect_wiki_link('%s called with arguments (%s)' % (display, args), link)


### PR DESCRIPTION
I forgot to fix this in the last PR, seen in 

https://34.105.185.241/sagemath/sage-all-2023-01-14-016/issues/15995#comment:0

Note that the parentheses enclosing the arguments are  unbalanced. Compare with 

https://github.com/kwankyu/trac-to-github/blob/check/wiki/Issues-15xxx/15995.md#comment:0

I did this only for wiki pages in the last PR!

