### PR TITLE
Fix ticket links in wiki conversion

### DIFF
--- a/migrate.cfg.example
+++ b/migrate.cfg.example
@@ -13,7 +13,7 @@ url: https://example.com/xmlrpc
 path: /path/to/trac/instance
 
 # if no, a trac ticket reference is converted to the corresponding issue reference
-keep_trac_ticket_references: yes
+keep_trac_ticket_references: no
 
 [issues]
 

--- a/migrate.cfg.sagetracwikionly
+++ b/migrate.cfg.sagetracwikionly
@@ -18,7 +18,7 @@ url: https://trac.sagemath.org/xmlrpc
 cgit_url: https://git.sagemath.org/sage.git/
 
 # if no, a trac ticket reference is converted to the corresponding issue reference
-keep_trac_ticket_references: yes
+keep_trac_ticket_references: no
 
 [issues]
 

--- a/migrate.py
+++ b/migrate.py
@@ -1302,7 +1302,7 @@ class WikiConversionHelper:
         if keep_trac_ticket_references:
             return r'[#%s](%s/%s)' % (ticket, trac_url_ticket, ticket)
         issue = ticket
-        return r'#%s' % ticket
+        return r'[#%s](%s/issues/%s)' % (issue, target_url_issues_repo, issue)
 
     def ticket_comment_link(self, match):
         """


### PR DESCRIPTION
Fixes https://github.com/sagemath/trac-to-github/issues/73#issuecomment-1418834768

Perhaps it's not too late. With this PR merged, we convert trac wiki pages again with right ticket links, and then **merge** with existing github wiki pages. There may be some conflicts because people already edited some part of the github wiki pages. But it would be much easier to fix these merge conflicts than manually editing all ticket links in github wiki pages manually!